### PR TITLE
Enable feature flag "+crc" for iPhone

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,9 @@ import PackageDescription
 
 let package = Package(
     name: "SevenZip",
+    platforms: [
+        .iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6) // Using SHA256 of CryptoKit
+    ],
     products: [
         .library(
             name: "SevenZip",

--- a/Package.swift
+++ b/Package.swift
@@ -100,6 +100,7 @@ let package = Package(
             ],
             cSettings: [
                 // .define("_SZ_ALLOC_DEBUG") // if you want to debug alloc/free operations to stderr.
+                .unsafeFlags(["-march=armv8+crc"], .when(platforms: [.iOS]))
             ]
         ),
         .testTarget(


### PR DESCRIPTION
rel. #1

- LZMA SDK uses ARM's CRC extension
  - https://github.com/mtgto/SevenZip.swift/blob/0.1.3/Sources/CsevenZip/7zCrc.c#L106
- Armv8+ can uses CRC extension
  - https://developer.arm.com/documentation/101754/0620/armclang-Reference/armclang-Command-line-Options/-march
- But Xcode disables crc feature while building for iPhone.
  - It is enabled for macOS
- This pull request sets `+crc` feature flag for iOS.