### PR TITLE
Release the Archive when its last reference goes

### DIFF
--- a/Sources/SevenZip/Archive.swift
+++ b/Sources/SevenZip/Archive.swift
@@ -15,7 +15,30 @@ private var moduleInit: Void = {
 }()
 
 public class Archive {
-    private(set) public var entries: [Entry] = []
+    /// The files the archive holds, rebuilt on every access.
+    ///
+    /// `Entry` keeps a strong reference to the archive it came from, so keeping the array in a
+    /// stored property forms a reference cycle: the archive is never released, and its file
+    /// handle, its index and `outBuffer` stay alive for the rest of the process even after the
+    /// last caller has dropped it. The per-file data lives in `entryRecords` instead, and the
+    /// `Entry` values -- which are what carries the back reference -- are made on demand.
+    public var entries: [Entry] {
+        entryRecords.map { record in
+            Entry(
+                index: record.index, path: record.path, uncompressedSize: record.uncompressedSize,
+                directory: record.directory, modified: record.modified, archive: self)
+        }
+    }
+
+    /// Everything `Entry` carries except the back reference to the archive.
+    private struct EntryRecord {
+        let index: UInt32
+        let path: String
+        let uncompressedSize: UInt64
+        let directory: Bool
+        let modified: Date?
+    }
+    private var entryRecords: [EntryRecord] = []
     private var allocImp = ISzAlloc(Alloc: SzAlloc, Free: SzFree)
     private var allocTempImp = ISzAlloc(Alloc: SzAlloc, Free: SzFree)
     private var db = CSzArEx()
@@ -55,7 +78,7 @@ public class Archive {
         if SzArEx_Open(&self.db, &self.lookStream.vt, &self.allocImp, &self.allocTempImp) != 0 {
             throw LZMAError.badFile
         }
-        self.entries = try (0..<self.db.NumFiles).map { i in
+        self.entryRecords = try (0..<self.db.NumFiles).map { i in
             let len = SzArEx_GetFileNameUtf16(&self.db, Int(i), nil)
             guard let temp = SzAlloc(nil, len * MemoryLayout<UInt16>.size)?.assumingMemoryBound(to: UInt16.self) else {
                 throw LZMAError.noMemory
@@ -77,8 +100,7 @@ public class Archive {
             } else {
                 mtime = nil
             }
-            let entry = Entry(index: i, path: filename, uncompressedSize: filesize, directory: isDirectory, modified: mtime, archive: self)
-            return entry
+            return EntryRecord(index: i, path: filename, uncompressedSize: filesize, directory: isDirectory, modified: mtime)
         }
     }
 

--- a/Tests/SevenZipTests/ArchiveLifetimeTests.swift
+++ b/Tests/SevenZipTests/ArchiveLifetimeTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+@testable import SevenZip
+
+/// `Archive` has to die when its last user lets go of it: it owns the archive's file
+/// descriptor, the parsed index and `outBuffer`, none of which are given back before
+/// `deinit` runs.
+///
+/// `Entry` holds a strong reference to its archive, so an `Archive` that also stored its
+/// `[Entry]` could never reach a retain count of zero.
+final class ArchiveLifetimeTests: XCTestCase {
+    private func sampleURL() throws -> URL {
+        try XCTUnwrap(Bundle.module.url(forResource: "sample", withExtension: "7z"))
+    }
+
+    func testArchiveIsReleasedWithItsLastReference() throws {
+        let url = try sampleURL()
+        weak var weakArchive: Archive?
+        try autoreleasepool {
+            var archive: Archive? = try Archive(fileURL: url)
+            weakArchive = archive
+            let entry = try XCTUnwrap(archive?.entries.first { !$0.directory && $0.uncompressedSize > 0 })
+            _ = try archive?.extract(entry: entry)
+            archive = nil
+        }
+        XCTAssertNil(weakArchive, "the archive outlived its last reference; its file handle and buffers leak")
+    }
+
+    /// The other half of the contract: an `Entry` kept by the caller keeps its archive alive,
+    /// so `entry.archive` never dangles.
+    func testAnEntryKeepsItsArchiveAlive() throws {
+        let url = try sampleURL()
+        weak var weakArchive: Archive?
+        var heldEntry: Entry?
+        try autoreleasepool {
+            var archive: Archive? = try Archive(fileURL: url)
+            weakArchive = archive
+            heldEntry = archive?.entries.first { !$0.directory && $0.uncompressedSize > 0 }
+            archive = nil
+        }
+        XCTAssertNotNil(weakArchive, "an entry must keep its archive alive")
+        try autoreleasepool {
+            let entry = try XCTUnwrap(heldEntry)
+            XCTAssertEqual(try entry.archive.extract(entry: entry).count, Int(entry.uncompressedSize))
+        }
+        heldEntry = nil
+        XCTAssertNil(weakArchive, "letting the last entry go must release the archive")
+    }
+}


### PR DESCRIPTION
`Entry` holds a strong reference to its `Archive`, and `Archive` stores the `[Entry]`. That is a reference cycle: **no `Archive` is ever deallocated**, so `deinit` never runs and the file descriptor, the parsed index (`SzArEx_Free`) and `outBuffer` stay resident for the life of the process — once for every archive ever opened.

```swift
weak var weak: Archive?
do {
    let archive = try Archive(fileURL: url)
    weak = archive
}
weak    // still non-nil
```

### The fix

Build the entries on access from a private `EntryRecord` (the same fields without the back reference) instead of storing them. Holding an `Entry` still keeps its `Archive` alive, so nothing can dangle — the observable semantics are unchanged, only the cycle is gone.

Making `Entry.archive` `unowned` would be the smaller diff, but it turns code that works today (keeping an entry after dropping the archive) into a crash, so I did not go that way. The cost of this version is that `entries` rebuilds the array on each access; callers that use it in a loop will want to bind it to a local first.

### Tests

`ArchiveLifetimeTests`: the archive dies with its last reference, and an entry keeps its archive alive. `swift test` passes; the first test fails without the fix.

One of four small independent PRs: `Entry.modified` (#5), this one, closing the file in `deinit` (#7), PPMd (#8). They do not depend on each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
