### PR TITLE
Close the archive file when the Archive is deallocated

### DIFF
--- a/Sources/SevenZip/Archive.swift
+++ b/Sources/SevenZip/Archive.swift
@@ -87,6 +87,8 @@ public class Archive {
             self.allocImp.Free(nil, pointee)
         }
         SzArEx_Free(&self.db, &self.allocImp)
+        // InFile_Open opened the file in init; nothing else closes it.
+        File_Close(&self.archiveStream.pointee.file)
         self.archiveStream.deinitialize(count: 1)
         self.archiveStream.deallocate()
     }


### PR DESCRIPTION
`init` opens the archive with `InFile_Open` and nothing ever closes it, so every `Archive` costs a file descriptor for the life of the process.

`SzArEx_Free` frees the index, not the file, and `CFileInStream` has no destructor of its own — `File_Close` has to be called explicitly.

### No test here, on purpose

`deinit` cannot run at all while `Archive` stores its `[Entry]` (`Entry` holds a strong reference back, so the two form a cycle — that is #6). With both changes in, this holds:

```swift
let before = try FileManager.default.contentsOfDirectory(atPath: "/dev/fd").count
for _ in 0..<200 { autoreleasepool { _ = try? Archive(fileURL: url) } }
let after = try FileManager.default.contentsOfDirectory(atPath: "/dev/fd").count
XCTAssertLessThan(after - before, 10)   // 200 without this fix
```

I am happy to add that test to whichever PR you merge second, or to fold the two together if you would rather have one change.

One of four small independent PRs: `Entry.modified` (#5), the archive lifetime (#6), this one, PPMd (#8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
